### PR TITLE
Adds Gunicorn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,5 @@ MAINTAINER Hans Keeler <hans.keeler@cfpb.gov>
 
 EXPOSE 5000
 
-CMD ["python", "app.py"]
+CMD ["gunicorn", "-c", "conf/gunicorn.py", "-b", "0.0.0.0:5000", "app:app"]
+

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ quite simple to build and launch.
     * [Flask Dev Server](http://flask.pocoo.org/docs/0.10/server/)
 
 
-            python app/app.py
+            python app.py
 
     * ...or [Gunicorn](http://gunicorn.org/)
 

--- a/README.md
+++ b/README.md
@@ -21,9 +21,17 @@ quite simple to build and launch.
         pip install -r requirements.txt
 
 1. Run it.
+    * [Flask Dev Server](http://flask.pocoo.org/docs/0.10/server/)
 
+        """
         python app/app.py
+        """
 
+    * ...or [Gunicorn](http://gunicorn.org/)
+
+        """
+        gunicorn -c conf/gunicorn.py -b localhost:5000 app:app
+        """
 
 ### Docker
 

--- a/README.md
+++ b/README.md
@@ -23,15 +23,13 @@ quite simple to build and launch.
 1. Run it.
     * [Flask Dev Server](http://flask.pocoo.org/docs/0.10/server/)
 
-        """
-        python app/app.py
-        """
+
+            python app/app.py
 
     * ...or [Gunicorn](http://gunicorn.org/)
 
-        """
-        gunicorn -c conf/gunicorn.py -b localhost:5000 app:app
-        """
+
+            gunicorn -c conf/gunicorn.py -b localhost:5000 app:app
 
 ### Docker
 

--- a/conf/gunicorn.py
+++ b/conf/gunicorn.py
@@ -1,0 +1,11 @@
+import multiprocessing
+
+# Number of workers based on Gunicorn docs:
+#   http://gunicorn-docs.readthedocs.org/en/latest/design.html#how-many-workers
+workers = multiprocessing.cpu_count() * 2 + 1
+
+# Logging
+loglevel = "info" 
+# "-" = stderr
+accesslog = "-"
+errorlog = "-"

--- a/conf/gunicorn.py
+++ b/conf/gunicorn.py
@@ -5,7 +5,7 @@ import multiprocessing
 workers = multiprocessing.cpu_count() * 2 + 1
 
 # Logging
-loglevel = "info" 
+loglevel = "info"
 # "-" = stderr
 accesslog = "-"
 errorlog = "-"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 flask==0.10.1
+gunicorn==19.3.0
 pytz==2015.2
 usaddress==0.4.6
 


### PR DESCRIPTION
Closes #5.

This PR adds [Gunicorn](http://gunicorn.org/) support for the API.

For details on the config settings, see [Configuration Overview](http://docs.gunicorn.org/en/latest/configure.html#configuration-file).

One interesting bit is how to determine the appropriate number of `workers` and `threads` for Gunicorn.  The general guideline is to use `cpus * 2 + 1`.  The `threads` setting is pretty new, so there's not much out there on best practices.  See [How Many Workers?](http://docs.gunicorn.org/en/latest/design.html#how-many-workers) for details.

**Note:** This PR has all the changes from #7, so you'll want to review/merge that one first.
