### PR TITLE
Moves status resource from /status to /

### DIFF
--- a/app.py
+++ b/app.py
@@ -100,7 +100,7 @@ class InvalidApiUsage(Exception):
 app = Flask(__name__)
 
 
-@app.route('/status', methods=['GET'])
+@app.route('/', methods=['GET'])
 def status():
     """
     Provides the current status of the address parsing service

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -14,7 +14,7 @@ class TestIntegration(object):
 
     def test_status(self):
         """
-        /status - simple request
+        / - simple request
         """
         # Setup
         from datetime import datetime
@@ -28,7 +28,7 @@ class TestIntegration(object):
         up_since = app.UP_SINCE
 
         # Test
-        rv = self.app.get('/status')
+        rv = self.app.get('/')
         data = json.loads(rv.data)
 
         assert_equals(data['service'], service)


### PR DESCRIPTION
In order to make the address parser compliant with https://github.com/cfpb/grasshopper/issues/123, the status endpoint has been moved from `/status` to `/`.
