### PR TITLE
Upgrade Python Packages

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 flask==0.10.1
 gunicorn==19.3.0
-pytz==2015.2
-usaddress==0.4.6
+pytz==2015.6
+usaddress==0.5.4
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 flask==0.10.1
 gunicorn==19.3.0
-pytz==2015.6
+pytz==2015.7
 usaddress==0.5.4
 

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,4 @@
-coverage==3.7.1
-flake8==2.4.0
-nose==1.3.6
-tox==2.0.1
+coverage==4.0.1
+flake8==2.5.0
+nose==1.3.7
+tox==2.1.1


### PR DESCRIPTION
Upgrades all Python packages to the latest version.

**Warning:** The upgrade from Coverage 3.x to 4.x breaks compatibility with the `.coverage` file format.  If you have a `.coverage` file in your project root, you'll need to delete it before running `coverage` or `tox`. 
