### PR TITLE
Adds X-Forward-For HTTP header support to Gunicorn

### DIFF
--- a/conf/gunicorn.py
+++ b/conf/gunicorn.py
@@ -9,3 +9,9 @@ loglevel = "info"
 # "-" = stderr
 accesslog = "-"
 errorlog = "-"
+
+# Accept X-Forwarded-For from reverse proxy:
+#   http://gunicorn-docs.readthedocs.org/en/latest/settings.html#forwarded-allow-ips
+#   http://gunicorn-docs.readthedocs.org/en/latest/deploy.html
+forwarded_allow_ips = "*"
+


### PR DESCRIPTION
In order to get the "real" IP of an HTTP client, and not the upstream reverse proxy's IP, Gunicorn needs to support the `X-Forward-For` HTTP header.

For more details, see:
- http://gunicorn-docs.readthedocs.org/en/latest/settings.html#forwarded-allow-ips
- http://gunicorn-docs.readthedocs.org/en/latest/deploy.html
