### PR TITLE
Refactor /parse, remove validation, support batch

### DIFF
--- a/app.py
+++ b/app.py
@@ -82,7 +82,6 @@ class USAddressParser(object):
         return addr_parts
 
 
-
     def parse(self, addr_str, profile_name=None):
         """
         Parses an address string using usaddress, method  based on `parse_method` init arg
@@ -186,7 +185,6 @@ def parse():
     except KeyError:
         raise InvalidApiUsage("'address' query param is required.")
 
-    method = params.get('method', 'tag')
     profile = params.get('profile', None)
 
     addr_parts = PARSER.parse(addr_str, profile)
@@ -207,7 +205,6 @@ def parse_batch():
     # FIXME: Remove "force", add explicit Content-Type handling
     body = request.get_json(force=True)
 
-    method = body.get('method', 'tag')
     profile = body.get('profile', None)
     addresses = body.get('addresses', None)
 

--- a/app.py
+++ b/app.py
@@ -63,7 +63,7 @@ class USAddressParser(object):
         """
         parsed = usaddress.parse(addr_str)
 
-        addr_parts = [{'type': self.standard_part_mapping[v], 'value': k} for k, v in parsed]
+        addr_parts = [{'code': self.standard_part_mapping[v], 'value': k} for k, v in parsed]
 
         return addr_parts
 
@@ -78,7 +78,7 @@ class USAddressParser(object):
             # FIXME: Shouldn't leak details of 'tag' method since it not longer a param
             raise AddressParserError("Could not parse address '{}' with 'tag' method".format(addr_str))
 
-        addr_parts = [{'type': self.standard_part_mapping[k], 'value': v} for k, v in tagged]
+        addr_parts = [{'code': self.standard_part_mapping[k], 'value': v} for k, v in tagged]
 
         return addr_parts
 
@@ -111,16 +111,16 @@ class USAddressParser(object):
             child_part_types = self.derived_part_mapping[derived_part_type]
 
             # Filter out all child parts not in current address
-            filtered_child_parts = filter(lambda x: x['type'] in child_part_types, addr_parts)
+            filtered_child_parts = filter(lambda x: x['code'] in child_part_types, addr_parts)
             child_part_values = map(lambda x: x['value'], filtered_child_parts)
 
             # Build a space-separated string of all available child parts
             derived_part_value = " ".join(child_part_values)
 
-            addr_parts.append({'type': derived_part_type, 'value': derived_part_value})
+            addr_parts.append({'code': derived_part_type, 'value': derived_part_value})
 
         # Validate all required fields are present
-        addr_part_types = map(lambda x: x['type'], addr_parts)
+        addr_part_types = map(lambda x: x['code'], addr_parts)
         missing_parts = filter(lambda x: x not in addr_part_types, profile_part_types)
 
         if missing_parts:

--- a/app.py
+++ b/app.py
@@ -34,6 +34,7 @@ def parse_with_tag(addr_str):
         # `tag` returns OrderedDict, ordered by address parts in original address string
         tagged = usaddress.tag(addr_str)[0].items()
     except usaddress.RepeatedLabelError:
+        
         # FIXME: Add richer logging here with contents of `rle` or chain exception w/ Python 3
         raise InvalidApiUsage("Could not parse address '{}' with 'tag' method".format(addr_str))
 
@@ -123,17 +124,26 @@ def parse_batch():
     except KeyError:
         raise InvalidApiUsage("'addresses' attribute is required.")
 
-    parsed_addresses = []
+    parsed = []
+    failed = []
     
     for addr_str in addresses:
         try:
             addr_parts = parse_method_dispatch[method](addr_str)
         except KeyError:
             raise InvalidApiUsage("Parsing method '{}' not supported.".format(method))
+        except InvalidApiUsage:
+            failed.append(addr_str)
 
-        parsed_addresses.append(addr_parts)
+        parsed.append({
+            'input': addr_str,
+            'parts': addr_parts
+        })
 
-    response = {'addresses': parsed_addresses}
+    response = {
+        'parsed': parsed, 
+        'failed': failed
+    }
 
     return jsonify(response)
 

--- a/app.py
+++ b/app.py
@@ -82,7 +82,7 @@ def status():
     return jsonify(status)
 
 
-@app.route('/parse', methods=['GET', 'POST'])
+@app.route('/parse', methods=['GET'])
 def parse():
     """
     Parses an address string into its component parts
@@ -105,6 +105,35 @@ def parse():
         'input': addr_str,
         'parts': addr_parts
     }
+
+    return jsonify(response)
+
+
+@app.route('/parse', methods=['POST'])
+def parse_batch():
+    """
+    Parses a batch of address strings into the component parts
+    """
+    # FIXME: Remove "force", add explicit Content-Type handling
+    body = request.get_json(force=True)
+    method = body.get('method', 'tag')
+
+    try:
+        addresses = body['addresses']
+    except KeyError:
+        raise InvalidApiUsage("'addresses' attribute is required.")
+
+    parsed_addresses = []
+    
+    for addr_str in addresses:
+        try:
+            addr_parts = parse_method_dispatch[method](addr_str)
+        except KeyError:
+            raise InvalidApiUsage("Parsing method '{}' not supported.".format(method))
+
+        parsed_addresses.append(addr_parts)
+
+    response = {'addresses': parsed_addresses}
 
     return jsonify(response)
 

--- a/app.py
+++ b/app.py
@@ -157,6 +157,7 @@ def parse_batch():
     body = request.get_json(force=True)
 
     method = body.get('method', 'tag')
+    profile = body.get('profile', None)
     addresses = body.get('addresses', None)
 
     if not addresses:
@@ -173,6 +174,10 @@ def parse_batch():
     for addr_str in addresses:
         try:
             addr_parts = parse_method_dispatch[method](addr_str)
+
+            if profile:
+                addr_parts = add_profile_addr_parts(profile, addr_parts)
+
         except KeyError:
             raise InvalidApiUsage("Parsing method '{}' not supported.".format(method))
         except InvalidApiUsage:

--- a/conf/gunicorn.py
+++ b/conf/gunicorn.py
@@ -14,4 +14,3 @@ errorlog = "-"
 #   http://gunicorn-docs.readthedocs.org/en/latest/settings.html#forwarded-allow-ips
 #   http://gunicorn-docs.readthedocs.org/en/latest/deploy.html
 forwarded_allow_ips = "*"
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ flask==0.10.1
 gunicorn==19.3.0
 pytz==2015.7
 usaddress==0.5.4
+PyYAML==3.11
 

--- a/rules.yaml
+++ b/rules.yaml
@@ -1,0 +1,148 @@
+# Address Parsing Rules 
+address_parts:
+
+  # Unfiltered set of address parts.  Currently maps directly to usaddress parts.
+  standard:
+    - id: &address_number
+      value: AddressNumber
+      description: 'address number'
+  
+    - id: &address_number_prefix
+      value: AddressNumberPrefix
+      description: 'a modifier before an address number, e.g. "Mile", "#"'
+  
+    - id: &address_number_suffix
+      value: AddressNumberSuffix
+      description: 'a modifier after an address number, e.g "B", "1/2"'
+  
+    - id: &building_name
+      value: BuildingName
+      description: 'the name of a building, e.g. "Atlanta Financial Center"'
+  
+    - id: &corner_of
+      value: CornerOf
+      description: 'words indicating that an address is a corner, e.g. "Junction", "corner of"'
+  
+    - id: &intersection_separator
+      value: IntersectionSeparator
+      description: 'a conjunction connecting parts of an intersection, e.g. "and", "&"'
+  
+    - id: &landmark_name
+      value: LandmarkName
+      description: 'the name of a landmark, e.g. "Wrigley Field", "Union Station"'
+  
+    - id: &not_address
+      value: NotAddress
+      description: "a non-address component that doesn't refer to a recipient"
+  
+    - id: &occupancy_type
+      value: OccupancyType
+      description: 'a type of occupancy within a building, e.g. "Suite", "Apt", "Floor"'
+  
+    - id: &occupancy_id
+      value: OccupancyIdentifier
+      description: 'the identifier of an occupancy, often a number or letter'
+  
+    - id: &city_name
+      value: PlaceName
+      description: 'city'
+  
+    - id: &recipient
+      value: Recipient
+      description: 'a non-address recipient, e.g. the name of a person/organization'
+  
+    - id: &state_name
+      value: StateName
+      description: 'state'
+ 
+    - id: &street_name
+      value: StreetName
+      description: 'street name, excluding type & direction'
+  
+    - id: &street_name_pre_directional
+      value: StreetNamePreDirectional
+      description: 'a direction before a street name, e.g. "North", "S"'
+  
+    - id: &street_name_pre_modifier
+      value: StreetNamePreModifier
+      description: 'a modifier before a street name that is not a direction, e.g. "Old"'
+  
+    - id: &street_name_pre_type
+      value: StreetNamePreType
+      description: 'a street type that comes before a street name, e.g. "Route", "Ave"'
+  
+    - id: &street_name_post_directional
+      value: StreetNamePostDirectional
+      description: 'a direction after a street name, e.g. "North", "S"'
+  
+    - id: &street_name_post_modifier
+      value: StreetNamePostModifier
+      description: 'a modifier adter a street name, e.g. "Ext"'
+  
+    - id: &street_name_post_type
+      value: StreetNamePostType
+      description: 'a street type that comes after a street name, e.g. "Avenue", "Rd"'
+  
+    - id: &subaddress_id
+      value: SubaddressIdentifier
+      description: 'the name/identifier of a subaddress component'
+  
+    - id: &subaddress_type
+      value: SubaddressType
+      description: 'a level of detail in an address that is not an occupancy within a building, e.g. "Building", "Tower"'
+  
+    - id: &usps_box_group_id
+      value: USPSBoxGroupID
+      description: 'the identifier of a USPS box group, usually a number'
+  
+    - id: &usps_box_group_type
+      value: USPSBoxGroupType
+      description: 'a name for a group of USPS boxes, e.g. "R"'
+  
+    - id: &postal_box_id
+      value: USPSBoxID
+      description: 'the identifier of a USPS box, usually a number'
+  
+    - id: &usps_box_type
+      value: USPSBoxType
+      description: 'a USPS box, e.g. "P.O. Box"'
+  
+    - id: &zip_code
+      value: ZipCode
+      description: 'zip code'
+
+  # Alternate address parts made up of multiple "standard" parts
+  aggregates:
+    - id: &address_number_full
+      description: 'combination of all parts for a street address e.g. no "city", "state", "zip"'
+      parts:
+        - *address_number_prefix
+        - *address_number
+        - *address_number_suffix
+
+    - id: &street_name_full
+      description: 'a modifier adter a street name, e.g. "Ext"'
+      parts:
+        - *street_name_pre_directional
+        - *street_name_pre_modifier
+        - *street_name_pre_type
+        - *street_name
+        - *street_name_post_type
+        - *street_name_post_directional
+        - *street_name_post_modifier
+  
+# Alternate parsing rulesets
+profiles:
+  - id: grasshopper
+    required:
+      - *address_number_full
+      - *street_name_full
+      - *state_name
+      - *zip_code
+    # TODO: "optional" may be useful if we start excluding all other parts
+    # optional:
+    #  - *city_name
+    # TODO: Include "invalid" address parts for added validation
+    # invalid:
+    #  - *corner_of
+    #  - *intersection_indicator

--- a/rules.yaml
+++ b/rules.yaml
@@ -4,115 +4,115 @@ address_parts:
   # Unfiltered set of address parts.  Currently maps directly to usaddress parts.
   standard:
     - id: &address_number address_number
-      value: AddressNumber
+      usaddress: AddressNumber
       description: 'address number'
   
     - id: &address_number_prefix address_number_prefix
-      value: AddressNumberPrefix
+      usaddress: AddressNumberPrefix
       description: 'a modifier before an address number, e.g. "Mile", "#"'
   
     - id: &address_number_suffix address_number_suffix
-      value: AddressNumberSuffix
+      usaddress: AddressNumberSuffix
       description: 'a modifier after an address number, e.g "B", "1/2"'
   
     - id: &building_name building_name
-      value: BuildingName
+      usaddress: BuildingName
       description: 'the name of a building, e.g. "Atlanta Financial Center"'
   
     - id: &corner_of corner_of
-      value: CornerOf
+      usaddress: CornerOf
       description: 'words indicating that an address is a corner, e.g. "Junction", "corner of"'
   
     - id: &intersection_separator intersection_separator
-      value: IntersectionSeparator
+      usaddress: IntersectionSeparator
       description: 'a conjunction connecting parts of an intersection, e.g. "and", "&"'
   
     - id: &landmark_name landmark_name
-      value: LandmarkName
+      usaddress: LandmarkName
       description: 'the name of a landmark, e.g. "Wrigley Field", "Union Station"'
   
     - id: &not_address not_address
-      value: NotAddress
+      usaddress: NotAddress
       description: "a non-address component that doesn't refer to a recipient"
   
     - id: &occupancy_type occupancy_type
-      value: OccupancyType
+      usaddress: OccupancyType
       description: 'a type of occupancy within a building, e.g. "Suite", "Apt", "Floor"'
   
     - id: &occupancy_id occupancy_id
-      value: OccupancyIdentifier
+      usaddress: OccupancyIdentifier
       description: 'the identifier of an occupancy, often a number or letter'
   
     - id: &city_name city_name
-      value: PlaceName
+      usaddress: PlaceName
       description: 'city'
   
     - id: &recipient recipient
-      value: Recipient
+      usaddress: Recipient
       description: 'a non-address recipient, e.g. the name of a person/organization'
   
     - id: &state_name state_name
-      value: StateName
+      usaddress: StateName
       description: 'state'
  
     - id: &street_name street_name
-      value: StreetName
+      usaddress: StreetName
       description: 'street name, excluding type & direction'
   
     - id: &street_name_pre_directional street_name_pre_directional
-      value: StreetNamePreDirectional
+      usaddress: StreetNamePreDirectional
       description: 'a direction before a street name, e.g. "North", "S"'
   
     - id: &street_name_pre_modifier street_name_pre_modifier
-      value: StreetNamePreModifier
+      usaddress: StreetNamePreModifier
       description: 'a modifier before a street name that is not a direction, e.g. "Old"'
   
     - id: &street_name_pre_type street_name_pre_type
-      value: StreetNamePreType
+      usaddress: StreetNamePreType
       description: 'a street type that comes before a street name, e.g. "Route", "Ave"'
   
     - id: &street_name_post_directional street_name_post_directional
-      value: StreetNamePostDirectional
+      usaddress: StreetNamePostDirectional
       description: 'a direction after a street name, e.g. "North", "S"'
   
     - id: &street_name_post_modifier street_name_post_modifier
-      value: StreetNamePostModifier
+      usaddress: StreetNamePostModifier
       description: 'a modifier adter a street name, e.g. "Ext"'
   
     - id: &street_name_post_type street_name_post_type
-      value: StreetNamePostType
+      usaddress: StreetNamePostType
       description: 'a street type that comes after a street name, e.g. "Avenue", "Rd"'
   
     - id: &subaddress_id subaddress_id
-      value: SubaddressIdentifier
+      usaddress: SubaddressIdentifier
       description: 'the name/identifier of a subaddress component'
   
     - id: &subaddress_type subaddress_type
-      value: SubaddressType
+      usaddress: SubaddressType
       description: 'a level of detail in an address that is not an occupancy within a building, e.g. "Building", "Tower"'
   
     - id: &usps_box_group_id usps_box_group_id
-      value: USPSBoxGroupID
+      usaddress: USPSBoxGroupID
       description: 'the identifier of a USPS box group, usually a number'
   
     - id: &usps_box_group_type usps_box_group_type
-      value: USPSBoxGroupType
+      usaddress: USPSBoxGroupType
       description: 'a name for a group of USPS boxes, e.g. "R"'
   
     - id: &postal_box_id postal_box_id
-      value: USPSBoxID
+      usaddress: USPSBoxID
       description: 'the identifier of a USPS box, usually a number'
   
     - id: &usps_box_type usps_box_type
-      value: USPSBoxType
+      usaddress: USPSBoxType
       description: 'a USPS box, e.g. "P.O. Box"'
   
     - id: &zip_code zip_code
-      value: ZipCode
+      usaddress: ZipCode
       description: 'zip code'
 
   # Alternate address parts made up of multiple "standard" parts
-  aggregates:
+  derived:
     - id: &address_number_full address_number_full
       description: 'combination of all parts for a street address e.g. no "city", "state", "zip"'
       parts:

--- a/rules.yaml
+++ b/rules.yaml
@@ -3,124 +3,124 @@ address_parts:
 
   # Unfiltered set of address parts.  Currently maps directly to usaddress parts.
   standard:
-    - id: &address_number
+    - id: &address_number address_number
       value: AddressNumber
       description: 'address number'
   
-    - id: &address_number_prefix
+    - id: &address_number_prefix address_number_prefix
       value: AddressNumberPrefix
       description: 'a modifier before an address number, e.g. "Mile", "#"'
   
-    - id: &address_number_suffix
+    - id: &address_number_suffix address_number_suffix
       value: AddressNumberSuffix
       description: 'a modifier after an address number, e.g "B", "1/2"'
   
-    - id: &building_name
+    - id: &building_name building_name
       value: BuildingName
       description: 'the name of a building, e.g. "Atlanta Financial Center"'
   
-    - id: &corner_of
+    - id: &corner_of corner_of
       value: CornerOf
       description: 'words indicating that an address is a corner, e.g. "Junction", "corner of"'
   
-    - id: &intersection_separator
+    - id: &intersection_separator intersection_separator
       value: IntersectionSeparator
       description: 'a conjunction connecting parts of an intersection, e.g. "and", "&"'
   
-    - id: &landmark_name
+    - id: &landmark_name landmark_name
       value: LandmarkName
       description: 'the name of a landmark, e.g. "Wrigley Field", "Union Station"'
   
-    - id: &not_address
+    - id: &not_address not_address
       value: NotAddress
       description: "a non-address component that doesn't refer to a recipient"
   
-    - id: &occupancy_type
+    - id: &occupancy_type occupancy_type
       value: OccupancyType
       description: 'a type of occupancy within a building, e.g. "Suite", "Apt", "Floor"'
   
-    - id: &occupancy_id
+    - id: &occupancy_id occupancy_id
       value: OccupancyIdentifier
       description: 'the identifier of an occupancy, often a number or letter'
   
-    - id: &city_name
+    - id: &city_name city_name
       value: PlaceName
       description: 'city'
   
-    - id: &recipient
+    - id: &recipient recipient
       value: Recipient
       description: 'a non-address recipient, e.g. the name of a person/organization'
   
-    - id: &state_name
+    - id: &state_name state_name
       value: StateName
       description: 'state'
  
-    - id: &street_name
+    - id: &street_name street_name
       value: StreetName
       description: 'street name, excluding type & direction'
   
-    - id: &street_name_pre_directional
+    - id: &street_name_pre_directional street_name_pre_directional
       value: StreetNamePreDirectional
       description: 'a direction before a street name, e.g. "North", "S"'
   
-    - id: &street_name_pre_modifier
+    - id: &street_name_pre_modifier street_name_pre_modifier
       value: StreetNamePreModifier
       description: 'a modifier before a street name that is not a direction, e.g. "Old"'
   
-    - id: &street_name_pre_type
+    - id: &street_name_pre_type street_name_pre_type
       value: StreetNamePreType
       description: 'a street type that comes before a street name, e.g. "Route", "Ave"'
   
-    - id: &street_name_post_directional
+    - id: &street_name_post_directional street_name_post_directional
       value: StreetNamePostDirectional
       description: 'a direction after a street name, e.g. "North", "S"'
   
-    - id: &street_name_post_modifier
+    - id: &street_name_post_modifier street_name_post_modifier
       value: StreetNamePostModifier
       description: 'a modifier adter a street name, e.g. "Ext"'
   
-    - id: &street_name_post_type
+    - id: &street_name_post_type street_name_post_type
       value: StreetNamePostType
       description: 'a street type that comes after a street name, e.g. "Avenue", "Rd"'
   
-    - id: &subaddress_id
+    - id: &subaddress_id subaddress_id
       value: SubaddressIdentifier
       description: 'the name/identifier of a subaddress component'
   
-    - id: &subaddress_type
+    - id: &subaddress_type subaddress_type
       value: SubaddressType
       description: 'a level of detail in an address that is not an occupancy within a building, e.g. "Building", "Tower"'
   
-    - id: &usps_box_group_id
+    - id: &usps_box_group_id usps_box_group_id
       value: USPSBoxGroupID
       description: 'the identifier of a USPS box group, usually a number'
   
-    - id: &usps_box_group_type
+    - id: &usps_box_group_type usps_box_group_type
       value: USPSBoxGroupType
       description: 'a name for a group of USPS boxes, e.g. "R"'
   
-    - id: &postal_box_id
+    - id: &postal_box_id postal_box_id
       value: USPSBoxID
       description: 'the identifier of a USPS box, usually a number'
   
-    - id: &usps_box_type
+    - id: &usps_box_type usps_box_type
       value: USPSBoxType
       description: 'a USPS box, e.g. "P.O. Box"'
   
-    - id: &zip_code
+    - id: &zip_code zip_code
       value: ZipCode
       description: 'zip code'
 
   # Alternate address parts made up of multiple "standard" parts
   aggregates:
-    - id: &address_number_full
+    - id: &address_number_full address_number_full
       description: 'combination of all parts for a street address e.g. no "city", "state", "zip"'
       parts:
         - *address_number_prefix
         - *address_number
         - *address_number_suffix
 
-    - id: &street_name_full
+    - id: &street_name_full street_name_full
       description: 'a modifier adter a street name, e.g. "Ext"'
       parts:
         - *street_name_pre_directional

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -58,6 +58,21 @@ class TestIntegration(object):
         assert_equals(500, data['statusCode'])
         assert_equals("Hey!  Don't do that!", data['error'])
 
+    def test_resource_not_found(self):
+        """
+        GET /bad-resource -> 404 on resource not found
+        """
+        # Setup
+        url = '/bad-resource'
+        
+        # Test
+        rv = self.app.get(url)
+        data = json.loads(rv.data)
+
+        assert_equals(404, rv.status_code)
+        assert_equals(404, data['statusCode'])
+        assert_equals("Resource not found", data['error'])
+   
     def test_parse_success(self):
         """
         GET /parse -> 200 with just address, and parses correctly
@@ -165,7 +180,6 @@ class TestIntegration(object):
         assert_equals(400, data['statusCode'])
         assert_equals("Parsing method '{}' not supported.".format(bad_method), data['error'])
 
-
     def test_parse_batch_success(self):
         """
         POST /parse -> 200 with just "addresses"
@@ -188,7 +202,6 @@ class TestIntegration(object):
         assert_equals(len(req_data['addresses']), len(resp_data['parsed']))
         assert_equals(len(resp_data['parsed'][0]['parts']), 7)
 
-
     def test_parse_batch_with_failed_parse(self):
         """
         POST /parse -> 200 with good and bad address strings
@@ -210,7 +223,6 @@ class TestIntegration(object):
         assert_equals(resp_data['failed'][0], '5 Arapahoe Plaza El Paso TX 88530')
         assert_equals(resp_data['parsed'][0]['input'], '1600 Pennsylvania Ave NW Washington DC 20006')
        
-
     def test_parse_batch_with_no_addresses(self):
         """
         POST /parse -> 400 with no 'addresses' array
@@ -225,7 +237,6 @@ class TestIntegration(object):
         assert_equals(400, resp.status_code)
         assert_equals(400, resp_data['statusCode'])
         assert_equals("'addresses' array not populated", resp_data['error'])       
-
 
     def test_parse_batch_with_too_many_addresses(self):
         """
@@ -249,7 +260,6 @@ class TestIntegration(object):
         assert_equals(400, resp.status_code)
         assert_equals(400, resp_data['statusCode'])
         assert_equals("'addresses' contained 4 elements, exceeding max of 3", resp_data['error'])
-
 
     def test_parse_batch_with_method_invalid(self):
         """

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -76,12 +76,12 @@ class TestUSAddressParser(object):
         # Setup
         addr_str = '1234 Main St., Sacramento CA 95818'
         expected = [
-            {'type': 'address_number', 'value': u'1234'},
-            {'type': 'street_name', 'value': u'Main'},
-            {'type': 'street_name_post_type', 'value': u'St.,'},
-            {'type': 'city_name', 'value': u'Sacramento'},
-            {'type': 'state_name', 'value': u'CA'},
-            {'type': 'zip_code', 'value': u'95818'}
+            {'code': 'address_number', 'value': u'1234'},
+            {'code': 'street_name', 'value': u'Main'},
+            {'code': 'street_name_post_type', 'value': u'St.,'},
+            {'code': 'city_name', 'value': u'Sacramento'},
+            {'code': 'state_name', 'value': u'CA'},
+            {'code': 'zip_code', 'value': u'95818'}
         ]
         cut = app.USAddressParser()
 
@@ -96,12 +96,12 @@ class TestUSAddressParser(object):
         # Setup
         addr_str = '1234 Main St., Sacramento CA 95818'
         expected = [
-            {'type': 'address_number', 'value': u'1234'},
-            {'type': 'street_name', 'value': u'Main'},
-            {'type': 'street_name_post_type', 'value': u'St.'},  # Strips comma
-            {'type': 'city_name', 'value': u'Sacramento'},
-            {'type': 'state_name', 'value': u'CA'},
-            {'type': 'zip_code', 'value': u'95818'}
+            {'code': 'address_number', 'value': u'1234'},
+            {'code': 'street_name', 'value': u'Main'},
+            {'code': 'street_name_post_type', 'value': u'St.'},  # Strips comma
+            {'code': 'city_name', 'value': u'Sacramento'},
+            {'code': 'state_name', 'value': u'CA'},
+            {'code': 'zip_code', 'value': u'95818'}
         ]
         cut = app.USAddressParser()
 
@@ -186,13 +186,13 @@ class TestAPI(object):
         expected = {
             'input': addr_str,
             'parts': [
-                {'type': 'address_number', 'value': '1600'},
-                {'type': 'street_name', 'value': 'Pennsylvania'},
-                {'type': 'street_name_post_type', 'value': 'Ave'},
-                {'type': 'street_name_post_directional', 'value': 'NW'},
-                {'type': 'city_name', 'value': 'Washington'},
-                {'type': 'state_name', 'value': 'DC'},
-                {'type': 'zip_code', 'value': '20006'}
+                {'code': 'address_number', 'value': '1600'},
+                {'code': 'street_name', 'value': 'Pennsylvania'},
+                {'code': 'street_name_post_type', 'value': 'Ave'},
+                {'code': 'street_name_post_directional', 'value': 'NW'},
+                {'code': 'city_name', 'value': 'Washington'},
+                {'code': 'state_name', 'value': 'DC'},
+                {'code': 'zip_code', 'value': '20006'}
             ]}
 
         # Test
@@ -213,15 +213,15 @@ class TestAPI(object):
         expected = {
             'input': addr_str,
             'parts': [
-                {'type': 'address_number', 'value': '1600'},
-                {'type': 'street_name', 'value': 'Pennsylvania'},
-                {'type': 'street_name_post_type', 'value': 'Ave'},
-                {'type': 'street_name_post_directional', 'value': 'NW'},
-                {'type': 'city_name', 'value': 'Washington'},
-                {'type': 'state_name', 'value': 'DC'},
-                {'type': 'zip_code', 'value': '20006'},
-                {'type': 'address_number_full', 'value': '1600'},
-                {'type': 'street_name_full', 'value': 'Pennsylvania Ave NW'}
+                {'code': 'address_number', 'value': '1600'},
+                {'code': 'street_name', 'value': 'Pennsylvania'},
+                {'code': 'street_name_post_type', 'value': 'Ave'},
+                {'code': 'street_name_post_directional', 'value': 'NW'},
+                {'code': 'city_name', 'value': 'Washington'},
+                {'code': 'state_name', 'value': 'DC'},
+                {'code': 'zip_code', 'value': '20006'},
+                {'code': 'address_number_full', 'value': '1600'},
+                {'code': 'street_name_full', 'value': 'Pennsylvania Ave NW'}
             ]}
 
         # Test

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -9,6 +9,7 @@ import yaml
 # Hack to get nose asserts to give diff against large lists
 assert_equals.__self__.maxDiff = None
 
+
 class TestUSAddressParser(object):
 
     def setup(self):
@@ -46,11 +47,11 @@ class TestUSAddressParser(object):
 
         # Test
         with assert_raises(ValueError) as context:
-            parser = app.USAddressParser(parse_method=parse_method)
+            app.USAddressParser(parse_method=parse_method)
 
         err_msg = context.exception.message
         assert_equals(err_msg, "Parse method '{}' not supported.".format(parse_method))
-         
+
     def test_init_with_rules_valid(self):
         """
         PARSER: init - with valid rules
@@ -97,7 +98,7 @@ class TestUSAddressParser(object):
         expected = [
             {'type': 'address_number', 'value': u'1234'},
             {'type': 'street_name', 'value': u'Main'},
-            {'type': 'street_name_post_type', 'value': u'St.'}, # Strips comma
+            {'type': 'street_name_post_type', 'value': u'St.'},  # Strips comma
             {'type': 'city_name', 'value': u'Sacramento'},
             {'type': 'state_name', 'value': u'CA'},
             {'type': 'zip_code', 'value': u'95818'}
@@ -167,7 +168,7 @@ class TestAPI(object):
         """
         # Setup
         url = '/bad-resource'
-        
+
         # Test
         rv = self.app.get(url)
         data = json.loads(rv.data)
@@ -193,7 +194,7 @@ class TestAPI(object):
                 {'type': 'state_name', 'value': 'DC'},
                 {'type': 'zip_code', 'value': '20006'}
             ]}
-        
+
         # Test
         rv = self.app.get('/parse?address={}'.format(addr_str))
         actual = json.loads(rv.data)
@@ -201,7 +202,7 @@ class TestAPI(object):
 
         assert_equals(200, status_code)
         assert_equals(expected, actual)
-        
+
     def test_parse_with_profile_success(self):
         """
         API: GET /parse -> 200 with address and profile
@@ -222,7 +223,7 @@ class TestAPI(object):
                 {'type': 'address_number_full', 'value': '1600'},
                 {'type': 'street_name_full', 'value': 'Pennsylvania Ave NW'}
             ]}
-        
+
         # Test
         rv = self.app.get('/parse?address={}&profile={}'.format(addr_str, profile))
         actual = json.loads(rv.data)
@@ -238,7 +239,7 @@ class TestAPI(object):
         # Setup
         profile = 'bad'
         expected = {
-            'statusCode': 400, 
+            'statusCode': 400,
             'error': "Parsing profile '{}' not supported".format(profile)
         }
         addr_str = '1600 Pennsylvania Ave NW Washington DC 20006'
@@ -321,25 +322,25 @@ class TestAPI(object):
         assert_equals(200, resp.status_code)
         assert_equals(resp_data['failed'][0], '5 Arapahoe Plaza El Paso TX 88530')
         assert_equals(resp_data['parsed'][0]['input'], '1600 Pennsylvania Ave NW Washington DC 20006')
-       
+
     def test_parse_batch_with_no_addresses(self):
         """
         API: POST /parse -> 400 with no 'addresses' array
         """
         # Setup
         req_json = json.dumps({})
-        
+
         # Test
         resp = self.app.post('/parse', data=req_json)
         resp_data = json.loads(resp.data)
 
         assert_equals(400, resp.status_code)
         assert_equals(400, resp_data['statusCode'])
-        assert_equals("'addresses' array not populated", resp_data['error'])       
+        assert_equals("'addresses' array not populated", resp_data['error'])
 
     def test_parse_batch_with_too_many_addresses(self):
         """
-        API: POST /parse -> 400 with 'addresses' array too big 
+        API: POST /parse -> 400 with 'addresses' array too big
         """
         # Setup
         req_data = {
@@ -351,7 +352,7 @@ class TestAPI(object):
             ]
         }
         req_json = json.dumps(req_data)
-       
+
         # Test
         resp = self.app.post('/parse', data=req_json)
         resp_data = json.loads(resp.data)


### PR DESCRIPTION
This PR does a few things:
1. Removes `/standardize` resource. (Closes #28)
2. Refactor's `/parse` resource.
   1. Response JSON has been refactored to an array of address parts, rather than explicit key/values. (Closes #23)
   2. Supports `POST` of up to 5000 address for batch parsing. (Closes #30)
   3. Removes validation code that was causing heartache within the geocoder.
      - **Note:** Some form of validation will likely return in the future...
3. Adds more tests.
