### PR TITLE
Change user Gunicorn process runs as in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@
 FROM python:2.7.9-onbuild
 MAINTAINER Hans Keeler <hans.keeler@cfpb.gov>
 
+USER daemon 
+
 EXPOSE 5000
 
 CMD ["gunicorn", "-c", "conf/gunicorn.py", "-b", "0.0.0.0:5000", "app:app"]
-


### PR DESCRIPTION
Switches user Gunicorn process runs under in-container from the default of `root` to a less-privileged `daemon` user, matching grasshopper's Docker setup.